### PR TITLE
Implement in-memory storage

### DIFF
--- a/src/storage/in-memory.ts
+++ b/src/storage/in-memory.ts
@@ -1,1 +1,37 @@
 // In-memory Map-based document storage
+// Provides basic persistence for the lifetime of the Node process.
+// This layer is intentionally simple: FastMCP runs single-threaded so
+// synchronous Map operations are effectively atomic.
+
+import { SystemDoc } from '../schema';
+
+export interface Storage {
+  store(systemName: string, doc: SystemDoc): void;
+  retrieve(systemName: string): SystemDoc | undefined;
+  exists(systemName: string): boolean;
+}
+
+/**
+ * Simple in-memory storage backed by a Map keyed by system name.
+ * Data is lost when the server restarts.
+ */
+export class InMemoryStorage implements Storage {
+  private storeMap = new Map<string, SystemDoc>();
+
+  /** Store or overwrite a document for the given system name. */
+  store(systemName: string, doc: SystemDoc): void {
+    this.storeMap.set(systemName, doc);
+  }
+
+  /** Retrieve the document for a system, if present. */
+  retrieve(systemName: string): SystemDoc | undefined {
+    return this.storeMap.get(systemName);
+  }
+
+  /** Check whether a document exists for the given system name. */
+  exists(systemName: string): boolean {
+    return this.storeMap.has(systemName);
+  }
+}
+
+export const storage = new InMemoryStorage();

--- a/tasks/!KANBAN_BOARD.md
+++ b/tasks/!KANBAN_BOARD.md
@@ -1,6 +1,5 @@
 ## TODO
 
-- [implement-in-memory-storage.md](./implement-in-memory-storage.md)
 - [implement-fastmcp-server.md](./implement-fastmcp-server.md)
 - [add-unit-tests.md](./add-unit-tests.md)
 - [setup-build-and-dev-scripts.md](./setup-build-and-dev-scripts.md)
@@ -10,6 +9,7 @@
 
 ## DOING
 
+- [implement-in-memory-storage.md](./implement-in-memory-storage.md)
 ## DONE
 
 - [plan-out-project.md](./plan-out-project.md)


### PR DESCRIPTION
## Summary
- move `implement-in-memory-storage` into **DOING** on the kanban board
- create Map-based storage implementation

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6855fec7b0f48324b77d8fdb6b99e7a0